### PR TITLE
+ Add ability to define Lava template for adding extra information on the Confirm screen.

### DIFF
--- a/cc_newspring/AttendedCheckin/Confirm.ascx
+++ b/cc_newspring/AttendedCheckin/Confirm.ascx
@@ -34,7 +34,11 @@
                                     DisplayType="Light" EnableResponsiveTable="true" ShowFooter="false" EmptyDataText="No People Selected" CssClass="three-col-with-controls"
                                     OnRowCommand="gPersonList_Print" OnRowDataBound="gPersonList_RowDataBound" OnGridRebind="gPersonList_GridRebind">
                                     <Columns>
-                                        <Rock:RockBoundField HeaderStyle-CssClass="col-xs-3" HeaderText="Name" ItemStyle-CssClass="col-xs-3" DataField="Name" />
+                                        <Rock:RockTemplateField HeaderStyle-CssClass="col-xs-3" HeaderText="Name" ItemStyle-CssClass="col-xs-3" >
+                                            <ItemTemplate>
+                                                <%# Eval("Name") %><asp:Literal ID="ltNotes" runat="server" />
+                                            </ItemTemplate>
+                                        </Rock:RockTemplateField>
                                         <Rock:RockBoundField HeaderStyle-CssClass="col-xs-1 centered" HeaderText="Age" ItemStyle-CssClass="col-xs-1 centered" DataField="Age" Visible="false" />
                                         <Rock:RockBoundField HeaderStyle-CssClass="col-xs-1 centered" HeaderText="Grade" ItemStyle-CssClass="col-xs-1 centered" DataField="Grade" Visible="false" />
                                         <Rock:RockBoundField HeaderStyle-CssClass="col-xs-2" HeaderText="Location" ItemStyle-CssClass="col-xs-2" DataField="Location" />


### PR DESCRIPTION
### About

Added a block setting which the user can use to define custom Lava for formatted extra data to be appended to the `Name` column on the Confirmation screen. This can be used to display extra information as needed without future customization to the code base.