### PR TITLE
+ Added block setting to sort groups by Name instead of Order on the Activity Select screen.

### DIFF
--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
@@ -39,6 +39,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
     [BooleanField( "Display Group Names", "By default location names are shown.  Check this option to show the group names instead.", false )]
     [BooleanField( "Remove Attendance On Checkout", "By default, the attendance is given a checkout date.  Select this option to completely remove attendance on checkout.", false )]
     [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Special Needs Attribute", "Select the person attribute used to filter kids with special needs.", true, false, "8B562561-2F59-4F5F-B7DC-92B2BB7BB7CF" )]
+    [BooleanField( "Sort Groups By Name", "If false then groups, if displayed, are sorted by the Order they have been placed in on the check-in configuration screen.", true )]
     public partial class ActivitySelect : CheckInBlock
     {
         #region Variables
@@ -47,6 +48,11 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
         /// Stores whether or not to display group names
         /// </summary>
         private static bool DisplayGroupNames;
+
+        /// <summary>
+        /// Stores whether or not to sort the groups by name or by inherent Order.
+        /// </summary>
+        private static bool SortGroupsByName;
 
         /// <summary>
         /// Gets the error when a page's parameter string is invalid.
@@ -146,6 +152,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 }
 
                 DisplayGroupNames = GetAttributeValue( "DisplayGroupNames" ).AsBoolean();
+                SortGroupsByName = GetAttributeValue( "SortGroupsByName" ).AsBoolean( true );
 
                 if ( person != null && person.GroupTypes.Any() )
                 {
@@ -842,7 +849,16 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 IEnumerable<ILiquidizable> locationItems = null;
                 if ( DisplayGroupNames )
                 {
-                    var allGroups = groupType.Groups.OrderBy( g => g.Group.Name ).ToList();
+                    var allGroups = groupType.Groups.ToList();
+                    if ( SortGroupsByName )
+                    {
+                        allGroups = allGroups.OrderBy( g => g.Group.Name ).ToList();
+                    }
+                    else
+                    {
+                        allGroups = allGroups.OrderBy( g => g.Group.Order ).ToList();
+                    }
+
                     if ( groupId > 0 )
                     {
                         var selectedGroup = allGroups.FirstOrDefault( g => g.Group.Id == groupId && g.Locations.Any( l => l.Location.Id == locationId ) );


### PR DESCRIPTION
### About

Allows a change in the default sort order (as a block setting) on the Activity Select screen so that Groups are sorted by Name instead of Order. This only applies if the `Display Group Names` option is also true.