### PR TITLE
Print Individually and Print all Labels fix

### DIFF
--- a/cc_newspring/AttendedCheckin/Confirm.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Confirm.ascx.cs
@@ -568,7 +568,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                         .OrderBy( l => l.PersonId )
                         .ThenBy( l => l.Order )
                         .ToList()
-                        .ForEach( l => l.LabelFile = urlRoot + l.LabelFile );
+                        .ForEach( l => l.LabelFile = urlRoot + l.LabelFile.Replace( urlRoot, "" ) );
 
                     if ( !GetAttributeValue( "ReprintDesignatedLabel" ).AsBoolean() )
                     {


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for Print all not working when "Print Individually" is set to "Yes". Caution, this has the potential to print a crazy amount of labels, not positive on its use case. (Fixes #57)

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed Print all not working when "Print Individually" is set to "Yes". 

---------

### Requested By

##### Who reported, requested, or paid for the change?

Reported in issue #57, Warranty fix

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

cc_newspring/AttendedCheckin/Confirm.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
