### PR TITLE
Check-in By Data View Support

### DIFF
--- a/Migrations/003_CheckinByDataView.cs
+++ b/Migrations/003_CheckinByDataView.cs
@@ -1,0 +1,47 @@
+using Rock.Plugin;
+
+namespace cc.newspring.AttendedCheckIn.Migrations
+{
+    [MigrationNumber( 3, "1.9.0" )]
+    public class CheckinByDataView : Migration
+    {
+        /// <summary>
+        /// The commands to run to migrate plugin to the specific version
+        /// </summary>
+        public override void Up()
+        {
+            // cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn.FilterGroupsByDataView:Active
+            RockMigrationHelper.UpdateWorkflowActionEntityAttribute( "E6490F9B-21C6-4D0F-AD15-9729AC22C094", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Active", "Active", "Should Service be used?", 0, @"False", "0B1FF2A0-D0CE-42A5-95BC-C65F02D14399" );
+            // cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn.FilterGroupsByDataView:Remove
+            RockMigrationHelper.UpdateWorkflowActionEntityAttribute( "E6490F9B-21C6-4D0F-AD15-9729AC22C094", "1EDAFDED-DFE6-4334-B019-6EECBA89E05A", "Remove", "Remove", "Select 'Yes' if groups should be removed.  Select 'No' if they should just be marked as excluded.", 1, @"True", "5EE8CC8E-455D-4115-88F4-81D224A30A28" );
+            // cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn.FilterGroupsByDataView:DataView Group Attribute
+            // RockMigrationHelper.UpdateWorkflowActionEntityAttribute( "E6490F9B-21C6-4D0F-AD15-9729AC22C094", "99B090AA-4D7E-46D8-B393-BF945EA1BA8B", "DataView Group Attribute", "DataViewGroupAttribute", "Select the attribute used to filter by DataView.", 0, @"E8F8498F-5C51-4216-AC81-875349D6C2D0", "7BBDBA2B-CD6B-4631-B274-50942E2FB2CE" );
+            // cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn.FilterGroupsByDataView:Order
+            RockMigrationHelper.UpdateWorkflowActionEntityAttribute( "E6490F9B-21C6-4D0F-AD15-9729AC22C094", "A75DFC58-7A1B-4799-BF31-451B2BBE38FF", "Order", "Order", "The order that this service should be used (priority)", 0, @"", "869473D0-AC93-4F8F-B164-2A332571E779" );
+
+            // Attended Check-in:Person Search:Filter Groups By Data View
+            RockMigrationHelper.UpdateWorkflowActionType( "6D8CC755-0140-439A-B5A3-97D2F7681697", "Filter Groups By Data View", 7, "E6490F9B-21C6-4D0F-AD15-9729AC22C094", true, false, "", "", 1, "", "A6D75C4C-F5DD-43DE-8403-96C6F35E225F" );
+            
+            // Change Order for new Action Type being added
+            // Attended Check-in:Activity Search:Remove Empty Group Types
+            RockMigrationHelper.UpdateWorkflowActionType( "6D8CC755-0140-439A-B5A3-97D2F7681697", "Remove Empty Group Types", 8, "E998B9A7-31C9-46F6-B91C-4E5C3F06C82F", true, false, "", "", 1, "", "9089B47B-B441-41DE-84A7-710F4E3E55EF" );
+            // Attended Check-in:Person Search:Remove Empty People
+            RockMigrationHelper.UpdateWorkflowActionType( "6D8CC755-0140-439A-B5A3-97D2F7681697", "Remove Empty People", 9, "B8B72812-190E-4802-A63F-E693344754BD", true, false, "", "", 1, "", "1813C89A-623C-4234-91D4-3243CA68CD03" );
+
+            // Attended Check-in:Person Search:Filter Groups By Data View:Active
+            RockMigrationHelper.AddActionTypeAttributeValue( "A6D75C4C-F5DD-43DE-8403-96C6F35E225F", "0B1FF2A0-D0CE-42A5-95BC-C65F02D14399", @"False" );
+            // Attended Check-in:Person Search:Filter Groups By Data View:DataView Group Attribute
+            //RockMigrationHelper.AddActionTypeAttributeValue( "A6D75C4C-F5DD-43DE-8403-96C6F35E225F", "7BBDBA2B-CD6B-4631-B274-50942E2FB2CE", @"e8f8498f-5c51-4216-ac81-875349d6c2d0" );
+            // Attended Check-in:Person Search:Filter Groups By Data View:Remove
+            RockMigrationHelper.AddActionTypeAttributeValue( "A6D75C4C-F5DD-43DE-8403-96C6F35E225F", "5EE8CC8E-455D-4115-88F4-81D224A30A28", @"False" );
+        }
+
+        /// <summary>
+        /// The commands to undo a migration from a specific version
+        /// </summary>
+        public override void Down()
+        {
+            // Handled by the down method in AddSystemData of deleting the workflow type.
+        }
+    }
+}

--- a/cc.newspring.AttendedCheckIn.csproj
+++ b/cc.newspring.AttendedCheckIn.csproj
@@ -33,13 +33,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotLiquid">
+      <HintPath>..\RockWeb\Bin\DotLiquid.dll</HintPath>
+    </Reference>
     <Reference Include="EntityFramework">
-      <HintPath>..\Rock\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\RockWeb\Bin\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\Rock\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\RockWeb\Bin\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock">
+      <HintPath>..\RockWeb\Bin\Rock.dll</HintPath>
+    </Reference>
+    <Reference Include="Rock.Rest">
+      <HintPath>..\RockWeb\Bin\Rock.Rest.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -57,6 +64,7 @@
   <ItemGroup>
     <Compile Include="Migrations\001_AddSystemData.cs" />
     <Compile Include="Migrations\002_FixSpecialNeeds.cs" />
+    <Compile Include="Migrations\003_CheckinByDataView.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\Helpers.cs" />
     <Compile Include="Workflow\Action\CheckIn\SelectByMultipleAttended.cs" />
@@ -66,23 +74,6 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\rock\DotLiquid\DotLiquid.csproj">
-      <Project>{00EDCB8D-EF33-459C-AD62-02876BD24DFF}</Project>
-      <Name>DotLiquid</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\rock\Rock.Rest\Rock.Rest.csproj">
-      <Project>{b89dfd33-ce93-44e1-8616-c31acdfe89cb}</Project>
-      <Name>Rock.Rest</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\rock\Rock\Rock.csproj">
-      <Project>{8f8c2a79-24f4-4157-8b99-45f75fa85799}</Project>
-      <Name>Rock</Name>
-      <Private>False</Private>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

+ Added support for new Filter Groups By Data View workflow action that was added in Rock version 9 (Check In by Data View group type) (Fixes #73)
+ Changed references to the DLL's for a more universal project file. (Rockit or Rock develop)

**New Settings:**

No new settings.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added support for new Filter Groups By Data View workflow action (Check in by Data View group type)

---------

### Requested By

##### Who reported, requested, or paid for the change?

Whitewater and Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

It does not add anything to the block UI. Technically it does add a new action to the attended check-in workflow configuration behind the scenes. If you want to disable the ability to change the person's group to anything other than what matches you must flip the "Remove" setting to `Yes` on each of the filters.

![image](https://user-images.githubusercontent.com/2990519/74053979-4afb5d00-499a-11ea-8b11-f86310666de0.png)


---------

### Change Log

##### What files does it affect?

- Migrations/003_CheckinByDataView.cs
- cc.newspring.AttendedCheckIn.csproj

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
