### PR TITLE
Barcode Scanning Fix

### DIFF
--- a/cc_newspring/AttendedCheckin/Admin.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Admin.ascx.cs
@@ -309,7 +309,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
             }
 
             // return if kiosk isn't active
-            if ( !CurrentCheckInState.Kiosk.HasActiveLocations( selectedGroupTypes ) )
+            if ( CurrentCheckInState != null && !CurrentCheckInState.Kiosk.HasActiveLocations( selectedGroupTypes ) )
             {
                 hfGroupTypes.Value = ViewState["hfGroupTypes"] as string;
                 maAlert.Show( "There are no active schedules for the selected grouptypes.", ModalAlertType.Information );

--- a/cc_newspring/AttendedCheckin/Search.ascx
+++ b/cc_newspring/AttendedCheckin/Search.ascx
@@ -123,14 +123,14 @@
             }
 
             // stop the keypress
-            e.preventDefault();
+            //e.preventDefault();
 
             lastKeyPress = date.getTime();
         });
 
         // set focus to the input unless on a touch device
         var isTouchDevice = 'ontouchstart' in document.documentElement;
-        if (!isTouchDevice) {
+        if (!isTouchDevice && autoFocusSearch) {
             var searchBar = $('.checkin-phone-entry');
             var currentValue = searchBar.val();
             searchBar.focus();

--- a/cc_newspring/AttendedCheckin/Search.ascx
+++ b/cc_newspring/AttendedCheckin/Search.ascx
@@ -83,7 +83,8 @@
         var keyboardBuffer = '';
         var swipeProcessing = false;
 
-        $(document).keydown(function (e) {
+        $(document).off('keypress');
+        $(document).on('keypress', function (e) {
             // Ctrl + M to go back
             if (e.keyCode === 77 && e.ctrlKey) {
                 window.location.href = "/attendedcheckin/admin?back=true";
@@ -92,8 +93,8 @@
 
             var date = new Date();
             // if the character is a line break stop buffering and call postback
-            if (keyboardBuffer.length > 1 && (e.key == 13 || e.which == 13 )) {
-                if (!swipeProcessing) {
+            if (e.which == 13) {
+                if (keyboardBuffer.length != 0 && !swipeProcessing) {
                     $('#hfSearchEntry').val(keyboardBuffer);
                     keyboardBuffer = '';
                     swipeProcessing = true;
@@ -101,12 +102,28 @@
                 }
             }
             else if (!e.ctrlKey) {
-                if ((date.getTime() - lastKeyPress) > 300) {
+                if ((date.getTime() - lastKeyPress) > 500) {
+                    // if it's been more than 500ms, assume it is a new wedge read, so start a new keyboardBuffer
                     keyboardBuffer = String.fromCharCode(e.which);
-                } else if ((date.getTime() - lastKeyPress) < 30) {
+                } else if ((date.getTime() - lastKeyPress) < 100) {
+                    // if it's been more less than 100ms, assume a wedge read is coming in and append to the keyboardBuffer
                     keyboardBuffer += String.fromCharCode(e.which);
                 }
             }
+
+            // if the character is a line break stop buffering and call postback
+            if (e.which == 13 && keyboardBuffer.length != 0) {
+                if (!swipeProcessing) {
+                    $('#hfSearchEntry').val(keyboardBuffer);
+                    keyboardBuffer = '';
+                    swipeProcessing = true;
+                    console.log('processing');
+                    window.location = "javascript:__doPostBack('hfSearchEntry', 'Wedge_Entry')";
+                }
+            }
+
+            // stop the keypress
+            e.preventDefault();
 
             lastKeyPress = date.getTime();
         });

--- a/cc_newspring/AttendedCheckin/Search.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Search.ascx.cs
@@ -21,6 +21,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
     [Description( "Attended Check-In Search block" )]
     [LinkedPage( "Admin Page" )]
     [BooleanField( "Show Key Pad", "Show the number key pad on the search screen", false )]
+    [BooleanField( "Enable Search Auto Focus", "Auto focus to search input on load. You will want to disable this if you are using a barcode scanner. (default: true)", true )]
     public partial class Search : CheckInBlock
     {
         #region Control Methods
@@ -83,8 +84,9 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                         localStorage.checkInGroupTypes = '{3}';
                     }}
                 }});
+                var autoFocusSearch = {4};
             </script>
-            ", CurrentTheme, CurrentKioskId, CurrentCheckinTypeId, CurrentGroupTypeIds.AsDelimited( "," ) );
+            ", CurrentTheme, CurrentKioskId, CurrentCheckinTypeId, CurrentGroupTypeIds.AsDelimited( "," ), GetAttributeValue( "EnableSearchAutoFocus" ).AsBoolean().ToString().ToLower() );
                 using ( var literalControl = new LiteralControl( script ) )
                 {
                     phScript.Controls.Add( literalControl );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Switch out keydown for keypress to match Rock's code in their check-in, works a bit more reliably. Unable to confirm if it fixes #72 completely but from what I could reproduce it seemed to help. (Fixes #72)

**New Setting**

- **Enable Search Auto Focus**, Auto focus to search input on load. You will want to disable this if you are using a barcode scanner. (default: true)

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Attempt to fix barcode scanning not always finding families

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty, reported in #72 

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/95908229-ffcff000-0d59-11eb-8178-f6e451114b28.png)

---------

### Change Log

##### What files does it affect?

cc_newspring/AttendedCheckin/Admin.ascx.cs
cc_newspring/AttendedCheckin/Search.ascx
cc_newspring/AttendedCheckin/Search.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No