### PR TITLE
F: Add Barcode functionality to Update Profile screen of ActivitySelect screen

### DIFF
--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx
@@ -160,6 +160,11 @@
                         </div>
                         <div class="row">
                             <div class="col-xs-6">
+                                <Rock:RockTextBox ID="tbBarcodes" runat="server" Label="Barcode" Placeholder="Enter a comma separated list of barcodes" />
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-6">
                                 <asp:PlaceHolder ID="phAttributes" runat="server" EnableViewState="false"></asp:PlaceHolder>
                             </div>
                         </div>

--- a/cc_newspring/AttendedCheckin/FamilySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/FamilySelect.ascx.cs
@@ -1344,15 +1344,17 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                     GroupMemberStatus = GroupMemberStatus.Active
                 };
 
+                var groupTypeRoleService = new GroupTypeRoleService( rockContext );
+                var childRole = groupTypeRoleService.Get( new Guid( Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_CHILD ) );
+                var adultRole = groupTypeRoleService.Get( new Guid( Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT ) );
+
                 if ( person.Age < 18 || person.AgeClassification == AgeClassification.Child )
                 {
-                    groupMember.GroupRoleId = familyGroupType.Roles.FirstOrDefault( r =>
-                        r.Guid == new Guid( Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_CHILD ) ).Id;
+                    groupMember.GroupRole = childRole;
                 }
                 else
                 {
-                    groupMember.GroupRoleId = familyGroupType.Roles.FirstOrDefault( r =>
-                        r.Guid == new Guid( Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT ) ).Id;
+                    groupMember.GroupRole = adultRole;
                 }
 
                 newGroupMembers.Add( groupMember );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

* Added Barcode textbox to Update Profile modal of ActivitySelect screen to allow setting/updating of barcodes for individual family members.  
* Fixed https://github.com/KingdomFirst/rock-attended-checkin/issues/80

**New Settings:**

none

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Added Barcode textbox to Update Profile modal of ActivitySelect screen to allow setting/updating of barcodes for individual family members.  
* Fixed bug causing Save to not work properly when barcode(s) added to the Add Family modal. (https://github.com/KingdomFirst/rock-attended-checkin/issues/80)

---------

### Requested By

##### Who reported, requested, or paid for the change?

Long Hollow

---------

### Screenshots

##### Does this update or add options to the block UI?

New "Barcode" textbox provide on Update Profile modal.  
![image](https://user-images.githubusercontent.com/7374281/130516142-5f0799ad-fe34-48e4-a1cf-a1f5bb7ed248.png)


---------

### Change Log

##### What files does it affect?

* cc_newspring/AttendedCheckin/ActivitySelect.ascx
* cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
* cc_newspring/AttendedCheckin/FamilySelect.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
