### PR TITLE
Trim barcodes in case someone puts spaces in them.

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.8.3.0" )]
-[assembly: AssemblyFileVersion( "1.8.3.0" )]
+[assembly: AssemblyVersion( "1.8.3.1" )]
+[assembly: AssemblyFileVersion( "1.8.3.1" )]

--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
@@ -806,19 +806,19 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 var personSearchKeyService = new PersonSearchKeyService( rockContext );
 
                 // Add new barcodes
-                foreach ( var value in barcode.Where( bc => !bcSearchKeyStrings.Any( k => k == bc ) ) )
+                foreach ( var value in barcode.Where( bc => !bcSearchKeyStrings.Any( k => k == bc.Trim() ) ) )
                 {
                     var searchValue = new PersonSearchKey
                     {
                         PersonAliasId = dbPerson.PrimaryAlias.Id,
                         SearchTypeValueId = searchTypeValue.Id,
-                        SearchValue = value
+                        SearchValue = value.Trim()
                     };
                     personSearchKeyService.Add( searchValue );
                 }
 
                 // Remove deleted barcodes
-                foreach ( var value in bcSearchKeys.Where( k => !barcode.Any( bc => bc == k.SearchValue ) ) )
+                foreach ( var value in bcSearchKeys.Where( k => !barcode.Any( bc => bc.Trim() == k.SearchValue ) ) )
                 {
                     personSearchKeyService.Delete( value );
                 }

--- a/cc_newspring/AttendedCheckin/FamilySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/FamilySelect.ascx.cs
@@ -1387,7 +1387,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                         {
                             PersonAliasId = hoh.PrimaryAlias.Id,
                             SearchTypeValueId = searchTypeValue.Id,
-                            SearchValue = value
+                            SearchValue = value.Trim()
                         };
                         personSearchKeyService.Add( searchValue );
                     }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Trim barcodes when adding to search keys, just in case someone adds spaces in their comma separated list.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed bug where barcodes could contain spaces.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Long Hollow / Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
- cc_newspring/AttendedCheckin/FamilySelect.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
