### PR TITLE
Replace DDL with DefinedValuePicker

### DIFF
--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx
@@ -133,7 +133,7 @@
                                 <Rock:RockTextBox ID="tbLastName" runat="server" Label="Last Name" ValidationGroup="Person" />
                             </div>
                             <div class="col-xs-1">
-                                <Rock:RockDropDownList ID="ddlSuffix" runat="server" Label="Suffix" />
+                                <Rock:DefinedValuePicker ID="dvpSuffix" runat="server" Label="Suffix"></Rock:DefinedValuePicker>
                             </div>
                             <div class="col-xs-2">
                                 <Rock:RockDropDownList ID="ddlPersonGender" runat="server" Label="Gender" />

--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
@@ -695,9 +695,9 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
             dbPerson.Gender = ddlPersonGender.SelectedValueAsEnum<Gender>();
             checkinPerson.Person.Gender = ddlPersonGender.SelectedValueAsEnum<Gender>();
 
-            History.EvaluateChange( profileChanges, "Suffix", dbPerson.SuffixValueId, ddlSuffix.SelectedValueAsId() );
-            dbPerson.SuffixValueId = ddlSuffix.SelectedValueAsId();
-            checkinPerson.Person.SuffixValueId = ddlSuffix.SelectedValueAsId();
+            History.EvaluateChange( profileChanges, "Suffix", dbPerson.SuffixValueId, dvpSuffix.SelectedValueAsId() );
+            dbPerson.SuffixValueId = dvpSuffix.SelectedValueAsId();
+            checkinPerson.Person.SuffixValueId = dvpSuffix.SelectedValueAsId();
 
             var DOB = dpDOB.SelectedDate;
             if ( DOB != null )
@@ -1092,7 +1092,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
             {
                 ddlAbilityGrade.LoadAbilityAndGradeItems();
                 ddlPersonGender.BindToEnum<Gender>();
-                ddlSuffix.BindToDefinedType( DefinedTypeCache.Get( new Guid( Rock.SystemGuid.DefinedType.PERSON_SUFFIX ) ), true );
+                dvpSuffix.DefinedTypeId = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.PERSON_SUFFIX.AsGuid() ).Id;
                 var personPhoneType = DefinedValueCache.Get( GetAttributeValue( "DefaultPhoneType" ).AsGuid() );
 
                 ViewState["lblAbilityGrade"] = ddlAbilityGrade.Label;
@@ -1115,7 +1115,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
 
                 if ( person.SuffixValueId.HasValue )
                 {
-                    ddlSuffix.SelectedValue = person.SuffixValueId.ToString();
+                    dvpSuffix.SetValue( person.SuffixValueId );
                 }
 
                 if ( person.GradeOffset.HasValue && person.GradeOffset.Value >= 0 && ddlAbilityGrade.Items.FindByValue( person.GradeOffset.ToString() ) != null )

--- a/cc_newspring/AttendedCheckin/FamilySelect.ascx
+++ b/cc_newspring/AttendedCheckin/FamilySelect.ascx
@@ -179,7 +179,7 @@
                                 <Rock:RockTextBox ID="tbLastName" runat="server" ValidationGroup="Person" />
                             </div>
                             <div class="col-xs-1 text-center hard-right">
-                                <Rock:RockDropDownList ID="ddlPersonSuffix" runat="server" CssClass="hard-sides" />
+                                <Rock:DefinedValuePicker ID="dvpPersonSuffix" runat="server" CssClass="hard-sides" ValidationGroup="Person"></Rock:DefinedValuePicker>
                             </div>
                             <div class="col-xs-2 text-center hard-right">
                                 <Rock:DatePicker ID="dpPersonDOB" runat="server" CssClass="date-picker hard-sides" ValidationGroup="Person" data-show-age="true" />
@@ -305,7 +305,7 @@
                                         <Rock:RockTextBox ID="tbLastName" runat="server" Text='<%# ((SerializedPerson)Container.DataItem).LastName %>' ValidationGroup="Family" CssClass="fill-lastname" />
                                     </div>
                                     <div class="col-xs-1 hard-right">
-                                        <Rock:RockDropDownList ID="ddlSuffix" runat="server" CssClass="hard-sides" />
+                                        <Rock:DefinedValuePicker ID="dvpSuffix" runat="server" CssClass="hard-sides"></Rock:DefinedValuePicker>
                                     </div>
                                     <div class="col-xs-2 hard-right">
                                         <Rock:DatePicker ID="dpBirthDate" runat="server" SelectedDate='<%# ((SerializedPerson)Container.DataItem).BirthDate %>' ValidationGroup="Family" CssClass="date-picker hard-sides" data-show-age="true" />

--- a/cc_newspring/AttendedCheckin/FamilySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/FamilySelect.ascx.cs
@@ -453,11 +453,11 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
             {
                 var person = ( (ListViewDataItem)e.Item ).DataItem as SerializedPerson;
 
-                var ddlSuffix = (RockDropDownList)e.Item.FindControl( "ddlSuffix" );
-                ddlSuffix.BindToDefinedType( DefinedTypeCache.Get( new Guid( Rock.SystemGuid.DefinedType.PERSON_SUFFIX ) ), true );
+                var dvpSuffix = (DefinedValuePicker)e.Item.FindControl( "dvpSuffix" );
+                dvpSuffix.DefinedTypeId = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.PERSON_SUFFIX.AsGuid() ).Id;
                 if ( person.SuffixValueId.HasValue )
                 {
-                    ddlSuffix.SelectedValue = person.SuffixValueId.ToString();
+                    dvpSuffix.SetValue( person.SuffixValueId );
                 }
 
                 var ddlGender = (RockDropDownList)e.Item.FindControl( "ddlGender" );
@@ -558,7 +558,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
             {
                 FirstName = tbFirstName.Text,
                 LastName = tbLastName.Text,
-                SuffixValueId = ddlPersonSuffix.SelectedValueAsId(),
+                SuffixValueId = dvpPersonSuffix.SelectedValue.AsIntegerOrNull(),
                 BirthDate = dpPersonDOB.SelectedDate,
                 Gender = ddlPersonGender.SelectedValueAsEnum<Gender>(),
                 Ability = ddlPersonAbilityGrade.SelectedValue,
@@ -716,7 +716,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 {
                     FirstName = ( (TextBox)item.FindControl( "tbFirstName" ) ).Text,
                     LastName = ( (TextBox)item.FindControl( "tbLastName" ) ).Text,
-                    SuffixValueId = ( (RockDropDownList)item.FindControl( "ddlSuffix" ) ).SelectedValueAsId(),
+                    SuffixValueId = ( (DefinedValuePicker)item.FindControl( "dvpSuffix" ) ).SelectedValueAsId(),
                     BirthDate = ( (DatePicker)item.FindControl( "dpBirthDate" ) ).SelectedDate,
                     Gender = ( (RockDropDownList)item.FindControl( "ddlGender" ) ).SelectedValueAsEnum<Gender>(),
                     Ability = ( (RockDropDownList)item.FindControl( "ddlAbilityGrade" ) ).SelectedValue,
@@ -811,7 +811,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 {
                     FirstName = ( (TextBox)item.FindControl( "tbFirstName" ) ).Text,
                     LastName = ( (TextBox)item.FindControl( "tbLastName" ) ).Text,
-                    SuffixValueId = ( (RockDropDownList)item.FindControl( "ddlSuffix" ) ).SelectedValueAsId(),
+                    SuffixValueId = ( (DefinedValuePicker)item.FindControl( "dvpSuffix" ) ).SelectedValueAsId(),
                     BirthDate = ( (DatePicker)item.FindControl( "dpBirthDate" ) ).SelectedDate,
                     Gender = ( (RockDropDownList)item.FindControl( "ddlGender" ) ).SelectedValueAsEnum<Gender>(),
                     Ability = ( (RockDropDownList)item.FindControl( "ddlAbilityGrade" ) ).SelectedValue,
@@ -1060,8 +1060,8 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
         {
             tbFirstName.Text = string.Empty;
             tbLastName.Text = string.Empty;
-            ddlPersonSuffix.BindToDefinedType( DefinedTypeCache.Get( new Guid( Rock.SystemGuid.DefinedType.PERSON_SUFFIX ) ), true );
-            ddlPersonSuffix.SelectedIndex = 0;
+            dvpPersonSuffix.DefinedTypeId = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.PERSON_SUFFIX.AsGuid() ).Id;
+            dvpPersonSuffix.SetValue( 0 );
             ddlPersonGender.BindToEnum<Gender>();
             ddlPersonGender.SelectedIndex = 0;
             ddlPersonAbilityGrade.LoadAbilityAndGradeItems();
@@ -1101,9 +1101,9 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 peopleQry = peopleQry.Where( p => p.FirstName.Equals( tbFirstName.Text ) );
             }
 
-            if ( ddlPersonSuffix.SelectedValueAsInt().HasValue )
+            if ( dvpPersonSuffix.SelectedValue.AsIntegerOrNull().HasValue )
             {
-                var suffixValueId = ddlPersonSuffix.SelectedValueAsId();
+                var suffixValueId = dvpPersonSuffix.SelectedValue.AsIntegerOrNull();
                 peopleQry = peopleQry.Where( p => p.SuffixValueId == suffixValueId );
             }
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Though we do not currently support v13, as reported in #92 replace DropDownList controls with DefinedValuePicker controls instead.

Fixes #92 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Replace obsolete methods in Family Select and Activity Select blocks

---------

### Requested By

##### Who reported, requested, or paid for the change?

Newspring/Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- cc_newspring/AttendedCheckin/FamilySelect.ascx
- cc_newspring/AttendedCheckin/FamilySelect.ascx.cs
- cc_newspring/AttendedCheckin/ActivitySelect.ascx
- cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Prior to v9, it would break, but v13 will remove this method, so needs to be fixed.