### PR TITLE
Grade, Date of Birth and Grade/Ability Level Fixes

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.8.6" )]
-[assembly: AssemblyFileVersion( "1.8.6" )]
+[assembly: AssemblyVersion( "1.8.7" )]
+[assembly: AssemblyFileVersion( "1.8.7" )]

--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
@@ -25,7 +25,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
     [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Person Special Needs Attribute", "Select the person attribute used to filter kids with special needs.", true, false, "8B562561-2F59-4F5F-B7DC-92B2BB7BB7CF", "", 3 )]
     [BooleanField( "Sort Groups By Name", "If false then groups, if displayed, are sorted by the Order they have been placed in on the check-in configuration screen.", true, "", 4 )]
     [AttributeField( Rock.SystemGuid.EntityType.PERSON, "Profile Attributes", "By default, Allergies and Legal Notes are displayed on Profile Edit.  Select others to allow editing.", false, true, "dbd192c9-0aa1-46ec-92ab-a3da8e056d31,f832ab6f-b684-4eea-8db4-c54b895c79ed", "", 5 )]
-    [BooleanField( "Track Assignment Changes", "By default, profile changes are tracked in Person History. Should changes to assignments be tracked as well?", false, "", 6)]
+    [BooleanField( "Track Assignment Changes", "By default, profile changes are tracked in Person History. Should changes to assignments be tracked as well?", false, "", 6 )]
     [DefinedValueField( "8345DD45-73C6-4F5E-BEBD-B77FC83F18FD", "Default Phone Type", "By default, the Home Phone type is stored on the person or family. Select a different type as the default.", false, false, "AA8732FB-2CEA-4C76-8D6D-6AAA2C6A4303", "", 7 )]
     public partial class ActivitySelect : CheckInBlock
     {
@@ -133,12 +133,12 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                     lblPersonName.Text = string.Format( "{0} {1}", nickName, person.Person.LastName );
                 }
 
-                DisplayPreference = (NameDisplay)GetAttributeValue( "DisplayNames" ).AsType<int>();
+                DisplayPreference = ( NameDisplay ) GetAttributeValue( "DisplayNames" ).AsType<int>();
 
                 if ( person != null && person.GroupTypes.Any() )
                 {
                     var selectedGroupTypeId = person.GroupTypes.Where( gt => gt.Selected )
-                        .Select( gt => (int?)gt.GroupType.Id ).FirstOrDefault();
+                        .Select( gt => ( int? ) gt.GroupType.Id ).FirstOrDefault();
                     if ( selectedGroupTypeId != null )
                     {
                         ViewState["groupTypeId"] = selectedGroupTypeId;
@@ -184,7 +184,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
 
             // instantiate attribute controls for reference later
             var attributeGuidList = GetAttributeValue( "ProfileAttributes" ).SplitDelimitedValues();
-            foreach( var attributeGuid in attributeGuidList )
+            foreach ( var attributeGuid in attributeGuidList )
             {
                 AttributeCache.Get( new Guid( attributeGuid ) ).AddControl( phAttributes.Controls, string.Empty, "", true, true );
             }
@@ -299,11 +299,11 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 {
                     if ( item.ID != e.Item.ID )
                     {
-                        ( (LinkButton)item.FindControl( "lbGroupType" ) ).RemoveCssClass( "active" );
+                        ( ( LinkButton ) item.FindControl( "lbGroupType" ) ).RemoveCssClass( "active" );
                     }
                     else
                     {
-                        ( (LinkButton)e.Item.FindControl( "lbGroupType" ) ).AddCssClass( "active" );
+                        ( ( LinkButton ) e.Item.FindControl( "lbGroupType" ) ).AddCssClass( "active" );
                     }
                 }
 
@@ -332,11 +332,11 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 {
                     if ( item.ID != e.Item.ID )
                     {
-                        ( (LinkButton)item.FindControl( "lbLocation" ) ).RemoveCssClass( "active" );
+                        ( ( LinkButton ) item.FindControl( "lbLocation" ) ).RemoveCssClass( "active" );
                     }
                     else
                     {
-                        ( (LinkButton)e.Item.FindControl( "lbLocation" ) ).AddCssClass( "active" );
+                        ( ( LinkButton ) e.Item.FindControl( "lbLocation" ) ).AddCssClass( "active" );
                     }
                 }
 
@@ -388,11 +388,11 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 {
                     if ( item.ID != e.Item.ID )
                     {
-                        ( (LinkButton)item.FindControl( "lbSchedule" ) ).RemoveCssClass( "active" );
+                        ( ( LinkButton ) item.FindControl( "lbSchedule" ) ).RemoveCssClass( "active" );
                     }
                     else
                     {
-                        ( (LinkButton)e.Item.FindControl( "lbSchedule" ) ).AddCssClass( "active" );
+                        ( ( LinkButton ) e.Item.FindControl( "lbSchedule" ) ).AddCssClass( "active" );
                     }
                 }
 
@@ -429,8 +429,8 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
         {
             if ( e.Item.ItemType == ListViewItemType.DataItem )
             {
-                var groupType = (CheckInGroupType)e.Item.DataItem;
-                var lbGroupType = (LinkButton)e.Item.FindControl( "lbGroupType" );
+                var groupType = ( CheckInGroupType ) e.Item.DataItem;
+                var lbGroupType = ( LinkButton ) e.Item.FindControl( "lbGroupType" );
                 lbGroupType.CommandArgument = groupType.GroupType.Id.ToString();
                 lbGroupType.Text = groupType.GroupType.Name;
 
@@ -451,13 +451,13 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
         {
             if ( e.Item.ItemType == ListViewItemType.DataItem )
             {
-                var lbLocation = (LinkButton)e.Item.FindControl( "lbLocation" );
+                var lbLocation = ( LinkButton ) e.Item.FindControl( "lbLocation" );
                 var itemSelected = false;
 
                 switch ( DisplayPreference )
                 {
                     case NameDisplay.Location:
-                        var location = (CheckInLocation)e.Item.DataItem;
+                        var location = ( CheckInLocation ) e.Item.DataItem;
                         lbLocation.Text = location.Location.Name;
                         lbLocation.CommandName = location.Location.Name;
                         lbLocation.CommandArgument = location.Location.Id.ToString();
@@ -465,7 +465,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                         break;
 
                     case NameDisplay.Group:
-                        var group = (CheckInGroup)e.Item.DataItem;
+                        var group = ( CheckInGroup ) e.Item.DataItem;
                         lbLocation.Text = group.Group.Name;
                         lbLocation.CommandName = group.Group.Name;
                         lbLocation.CommandArgument = group.Locations.Select( l => l.Location.Id ).FirstOrDefault().ToStringSafe();
@@ -474,7 +474,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
 
                     case NameDisplay.GroupLocation:
                         var locationId = ViewState["locationId"] as int?;
-                        var checkInGroup = (CheckInGroup)e.Item.DataItem;
+                        var checkInGroup = ( CheckInGroup ) e.Item.DataItem;
                         var checkInLocation = checkInGroup.Locations.FirstOrDefault( l => l.Location.Id == locationId ) ?? checkInGroup.Locations.FirstOrDefault();
                         lbLocation.Text = string.Format( "{0} / {1}", checkInGroup.Group.Name, checkInLocation.Location.Name );
                         lbLocation.CommandName = checkInGroup.Group.Name;
@@ -499,8 +499,8 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
         {
             if ( e.Item.ItemType == ListItemType.Item || e.Item.ItemType == ListItemType.AlternatingItem )
             {
-                var schedule = (CheckInSchedule)e.Item.DataItem;
-                var lbSchedule = (LinkButton)e.Item.FindControl( "lbSchedule" );
+                var schedule = ( CheckInSchedule ) e.Item.DataItem;
+                var lbSchedule = ( LinkButton ) e.Item.FindControl( "lbSchedule" );
                 lbSchedule.CommandArgument = schedule.Schedule.Id.ToString();
                 if ( schedule.Selected )
                 {
@@ -703,12 +703,12 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
             if ( DOB != null )
             {
                 History.EvaluateChange( profileChanges, "Date of Birth", dbPerson.BirthDate, dpDOB.SelectedDate );
-                dbPerson.BirthDay = ( (DateTime)DOB ).Day;
-                checkinPerson.Person.BirthDay = ( (DateTime)DOB ).Day;
-                dbPerson.BirthMonth = ( (DateTime)DOB ).Month;
-                checkinPerson.Person.BirthMonth = ( (DateTime)DOB ).Month;
-                dbPerson.BirthYear = ( (DateTime)DOB ).Year;
-                checkinPerson.Person.BirthYear = ( (DateTime)DOB ).Year;
+                dbPerson.BirthDay = ( ( DateTime ) DOB ).Day;
+                checkinPerson.Person.BirthDay = ( ( DateTime ) DOB ).Day;
+                dbPerson.BirthMonth = ( ( DateTime ) DOB ).Month;
+                checkinPerson.Person.BirthMonth = ( ( DateTime ) DOB ).Month;
+                dbPerson.BirthYear = ( ( DateTime ) DOB ).Year;
+                checkinPerson.Person.BirthYear = ( ( DateTime ) DOB ).Year;
             }
 
             if ( !string.IsNullOrWhiteSpace( tbPhone.Text ) )
@@ -745,7 +745,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 }
             }
 
-            History.EvaluateChange( profileChanges, "Email", dbPerson.Email, tbEmail.Text);
+            History.EvaluateChange( profileChanges, "Email", dbPerson.Email, tbEmail.Text );
             dbPerson.Email = tbEmail.Text;
             checkinPerson.Person.Email = tbEmail.Text;
 
@@ -953,10 +953,11 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                         allGroups.Clear();
                         foreach ( var group in groupType.Groups )
                         {
-                            foreach( var location in group.Locations )
+                            foreach ( var location in group.Locations )
                             {
                                 // bind a lightweight model with a single group/location
-                                allGroups.Add( new CheckInGroup {
+                                allGroups.Add( new CheckInGroup
+                                {
                                     Group = group.Group,
                                     Locations = new List<CheckInLocation> { location },
                                     Selected = group.Selected && location.Selected
@@ -1050,7 +1051,8 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                         foreach ( var schedule in location.Schedules.Where( s => s.Selected ) )
                         {
                             var selectionName = string.Empty;
-                            switch ( DisplayPreference ) {
+                            switch ( DisplayPreference )
+                            {
                                 case NameDisplay.Location:
                                     selectionName = location.Location.Name;
                                     break;
@@ -1094,7 +1096,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
             var currentPersonId = Request.QueryString["personId"].AsType<int?>();
             if ( currentPersonId.HasValue )
             {
-                person = new PersonService( new RockContext() ).Get( (int)currentPersonId );
+                person = new PersonService( new RockContext() ).Get( ( int ) currentPersonId );
             }
 
             if ( person != null )
@@ -1111,7 +1113,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 tbLastName.Text = person.LastName;
                 tbNickname.Text = person.NickName;
                 dpDOB.SelectedDate = person.BirthDate;
-                ddlPersonGender.SelectedIndex = (int)person.Gender;
+                ddlPersonGender.SelectedIndex = ( int ) person.Gender;
                 cbSpecialNeeds.Checked = person.GetAttributeValue( SpecialNeedsKey ).AsBoolean();
 
                 tbPhone.Label = personPhoneType.Value + " Phone";

--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
@@ -670,7 +670,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbSaveEditInfo_Click( object sender, EventArgs e )
         {
-            if ( string.IsNullOrEmpty( tbFirstName.Text ) || string.IsNullOrEmpty( tbLastName.Text ) || string.IsNullOrEmpty( dpDOB.Text ) )
+            if ( string.IsNullOrEmpty( tbFirstName.Text ) || string.IsNullOrEmpty( tbLastName.Text ) )
             {
                 Page.Validate( "Person" );
                 mdlInfo.Show();
@@ -770,6 +770,15 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                     dbPerson.GradeOffset = ddlAbilityGrade.SelectedValueAsId();
                     checkinPerson.Person.GradeOffset = ddlAbilityGrade.SelectedValueAsId();
                 }
+            }
+            else
+            {
+                History.EvaluateChange( profileChanges, "Ability Level", dbPerson.GetAttributeValue( "AbilityLevel" ), string.Empty );
+                dbPerson.SetAttributeValue( "AbilityLevel", string.Empty );
+                checkinPerson.Person.SetAttributeValue( "AbilityLevel", string.Empty );
+                History.EvaluateChange( profileChanges, "Grade", dbPerson.GradeFormatted, string.Empty );
+                dbPerson.GradeOffset = null;
+                checkinPerson.Person.GradeOffset = null;
             }
 
             // Always save the special needs value
@@ -1111,7 +1120,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
 
                 tbFirstName.Required = true;
                 tbLastName.Required = true;
-                dpDOB.Required = true;
+                dpDOB.Required = person.BirthDate.HasValue;
 
                 if ( person.SuffixValueId.HasValue )
                 {

--- a/cc_newspring/AttendedCheckin/Confirm.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Confirm.ascx.cs
@@ -478,7 +478,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
         /// <param name="checkinArray">The checkin array.</param>
         private void ProcessLabels( DataKeyArray checkinArray )
         {
-            if ( checkinArray.Count == 0)
+            if ( checkinArray.Count == 0 )
             {
                 return;
             }
@@ -692,8 +692,8 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                     .SelectMany( s => s.Schedules ).Where( s => s.Selected ).ToList();
                 foreach ( var selectedSchedule in selectedSchedules )
                 {
-                    var serviceStart = (DateTime)selectedSchedule.StartTime;
-                    selectedSchedule.LastCheckIn = serviceStart.AddMinutes( (double)selectedSchedule.Schedule.CheckInEndOffsetMinutes );
+                    var serviceStart = ( DateTime ) selectedSchedule.StartTime;
+                    selectedSchedule.LastCheckIn = serviceStart.AddMinutes( ( double ) selectedSchedule.Schedule.CheckInEndOffsetMinutes );
                 }
             }
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

1. Fixes #95, remove default "K" grade for grades over/under the max offset, change to using actual abbreviations from defined type.
2. Remove Date of Birth required field validator, if they have a date of birth do not let them remove it, but if it is empty initially, disable the validator. 
3. Add capability to clear ability/grade from Update Profile modal.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

1. Fixes #95, remove default "K" grade for grades over/under the max offset, change to using actual abbreviations from defined type.
2. Remove Date of Birth required field validator, if they have a date of birth do not let them remove it, but if it is empty initially, disable the validator. 
3. Add capability to clear ability/grade from Update Profile modal.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Long Hollow

---------

### Screenshots

##### Does this update or add options to the block UI?

Example of default changed if graduation year offset more than a value in the defined type:   
![image](https://user-images.githubusercontent.com/2990519/159547215-3786103c-ea40-41b5-85fa-702db62d41a9.png)

Before ability level/grade removed:   
![image](https://user-images.githubusercontent.com/2990519/159547692-49707764-68bb-47af-bea0-b6a9c43ec3c0.png)

After ability level/grade saved as empty:   
![image](https://user-images.githubusercontent.com/2990519/159547849-b882dec9-4022-4b1f-a4bc-add5e816c8d2.png)

If user does not have a DOB the field validator is removed so you can update other fields:   
![image](https://user-images.githubusercontent.com/2990519/159548066-e780ced5-9c9c-4121-9bf5-e0961da64866.png)

---------

### Change Log

##### What files does it affect?

- cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
- cc_newspring/AttendedCheckin/Confirm.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
