### PR TITLE
Confirm block - Fixed ambiguous reference bug caused by Rock v16.6 changes

### DIFF
--- a/cc_newspring/AttendedCheckin/Confirm.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Confirm.ascx.cs
@@ -19,6 +19,7 @@ using Rock.Model;
 using Rock.Web.Cache;
 using Rock.Web.UI;
 using Rock.Web.UI.Controls;
+using CheckInLabel = Rock.CheckIn.CheckInLabel;
 
 namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
 {


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Rock added a new CheckInLabel class to Rock.Model in v [16.6](https://github.com/SparkDevNetwork/Rock/commit/f36a49f54ac9c73e063927b717634e1ce3d6099d#diff-ada733893782d8d503f6997750703c30c2c147d479025f288f011eb92c7d5cdc), causing an ambiguous reference with Rock.Checkin.CheckInLabel class when both namespaces are referenced. This change resolves the ambiguous reference.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed CheckInLabel ambiguous reference error introduced with version 16.6 of Rock.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

* cc_newspring/AttendedCheckin/Confirm.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
